### PR TITLE
Change condition order in settings.php for Drupal

### DIFF
--- a/redis/scripts/setup-drupal-settings.sh
+++ b/redis/scripts/setup-drupal-settings.sh
@@ -23,6 +23,6 @@ SETTINGS_FILE_NAME="${DDEV_APPROOT}/${DDEV_DOCROOT}/sites/default/settings.php"
 echo "Settings file name: ${SETTINGS_FILE_NAME}"
 grep -qF 'settings.ddev.redis.php' $SETTINGS_FILE_NAME || echo "
 // Include settings required for Redis cache.
-if ((file_exists(__DIR__ . '/settings.ddev.redis.php') && getenv('IS_DDEV_PROJECT') == 'true')) {
+if (getenv('IS_DDEV_PROJECT') == 'true' && file_exists(__DIR__ . '/settings.ddev.redis.php')) {
   include __DIR__ . '/settings.ddev.redis.php';
 }" >> $SETTINGS_FILE_NAME


### PR DESCRIPTION
## The Issue

Align with the condition from the default ddev config. Check the env-var first and save the IO of file_exists.

## How This PR Solves The Issue

## Manual Testing Instructions

Using Drupal quickstart https://ddev.readthedocs.io/en/stable/users/quickstart/#drupal

```
ddev add-on get https://github.com/webflo/ddev-redis/tarball/patch-1
tail -n10 web/sites/default/settings.php
ddev restart
```

## Automated Testing Overview

## Release/Deployment Notes

