### PR TITLE
feat: change redis container hostname with env, show details in `ddev describe`, update constraint to v1.24.10

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ All customization options (use with caution):
 | Variable | Flag | Default |
 | -------- | ---- | ------- |
 | `REDIS_DOCKER_IMAGE` | `--redis-docker-image` | `redis:7` |
+| `REDIS_HOSTNAME` | `--redis-hostname` | `redis` |
 | `REDIS_OPTIMIZED` | `--redis-optimized` | `false` (`true`/`false`) |
 
 ## Credits

--- a/commands/host/redis-backend
+++ b/commands/host/redis-backend
@@ -44,6 +44,11 @@ function optimize_config() {
   ddev dotenv set .ddev/.env.redis --redis-optimized=true
 }
 
+function change_hostname() {
+  [[ "${REDIS_HOSTNAME:-}" == "" ]] && return
+  ddev dotenv set .ddev/.env.redis --redis-hostname="$REDIS_HOSTNAME"
+}
+
 function cleanup() {
   rm -f "$DDEV_APPROOT/.ddev/.env.redis"
   rm -rf "$DDEV_APPROOT/.ddev/redis/"
@@ -82,10 +87,12 @@ case "$REDIS_DOCKER_IMAGE" in
   valkey)
     NAME="Valkey 8"
     REDIS_DOCKER_IMAGE="valkey/valkey:8"
+    REDIS_HOSTNAME="valkey"
     ;;
   valkey-alpine)
     NAME="Valkey 8 Alpine"
     REDIS_DOCKER_IMAGE="valkey/valkey:8-alpine"
+    REDIS_HOSTNAME="valkey"
     ;;
   ""|--help|-h)
     show_help
@@ -99,6 +106,7 @@ esac
 check_docker_image
 cleanup
 optimize_config
+change_hostname
 use_docker_image
 
 echo

--- a/commands/redis/redis-cli
+++ b/commands/redis/redis-cli
@@ -7,7 +7,7 @@
 ## Aliases: redis
 
 if [ -f /etc/redis/conf/security.conf ]; then
-  redis-cli -p 6379 -h redis -a redis --no-auth-warning $@
+  redis-cli -p 6379 -h "${REDIS_HOSTNAME:-redis}" -a redis --no-auth-warning $@
 else
-  redis-cli -p 6379 -h redis $@
+  redis-cli -p 6379 -h "${REDIS_HOSTNAME:-redis}" $@
 fi

--- a/commands/redis/redis-flush
+++ b/commands/redis/redis-flush
@@ -6,7 +6,7 @@
 ## Example: "ddev redis-flush"
 
 if [ -f /etc/redis/conf/security.conf ]; then
-  redis-cli -p 6379 -h redis -a redis --no-auth-warning FLUSHALL ASYNC
+  redis-cli -p 6379 -h "${REDIS_HOSTNAME:-redis}" -a redis --no-auth-warning FLUSHALL ASYNC
 else
-  redis-cli -p 6379 -h redis FLUSHALL ASYNC
+  redis-cli -p 6379 -h "${REDIS_HOSTNAME:-redis}" FLUSHALL ASYNC
 fi

--- a/docker-compose.redis.yaml
+++ b/docker-compose.redis.yaml
@@ -3,6 +3,7 @@ services:
   redis:
     container_name: ddev-${DDEV_SITENAME}-redis
     image: ${REDIS_DOCKER_IMAGE:-redis:7}
+    hostname: ${REDIS_HOSTNAME:-redis}
     # These labels ensure this service is discoverable by ddev.
     labels:
       com.ddev.site-name: ${DDEV_SITENAME}

--- a/docker-compose.redis.yaml
+++ b/docker-compose.redis.yaml
@@ -17,6 +17,12 @@ services:
       - "./redis:/etc/redis/conf"
       - "redis:/data"
     command: /etc/redis/conf/redis.conf
+    x-ddev:
+      describe-url-port: |
+        Backend: ${REDIS_DOCKER_IMAGE:-redis:7}
+      describe-info: |
+        User: default
+        Pass: <none>
 
 volumes:
   redis:

--- a/docker-compose.redis.yaml
+++ b/docker-compose.redis.yaml
@@ -21,7 +21,6 @@ services:
       describe-url-port: |
         Backend: ${REDIS_DOCKER_IMAGE:-redis:7}
       describe-info: |
-        User: default
         Pass: <none>
 
 volumes:

--- a/install.yaml
+++ b/install.yaml
@@ -18,7 +18,7 @@ project_files:
   - commands/redis/redis-cli
   - commands/redis/redis-flush
 
-ddev_version_constraint: '>= v1.24.3'
+ddev_version_constraint: '>= v1.24.10'
 
 post_install_actions:
   - |

--- a/redis/scripts/setup-redis-optimized-config.sh
+++ b/redis/scripts/setup-redis-optimized-config.sh
@@ -65,6 +65,10 @@ services:
         reservations:
           cpus: "1.5"
           memory: "512M"
+    x-ddev:
+      describe-info: |
+        User: redis
+        Pass: redis
 EOF
 fi
 

--- a/tests/test.bats
+++ b/tests/test.bats
@@ -91,7 +91,6 @@ health_checks() {
     run ddev describe
     assert_success
     assert_output --partial "Backend:"
-    assert_output --partial "User: default"
     assert_output --partial "Pass: <none>"
   fi
 

--- a/tests/test.bats
+++ b/tests/test.bats
@@ -77,10 +77,22 @@ health_checks() {
 
     run grep -F "${PROJNAME}" .ddev/redis/snapshots.conf
     assert_output "dbfilename ${PROJNAME}.rdb"
+
+    run ddev describe
+    assert_success
+    assert_output --partial "Backend:"
+    assert_output --partial "User: redis"
+    assert_output --partial "Pass: redis"
   else
     for file in "${redis_optimized_files[@]}"; do
       assert_file_not_exist "$file"
     done
+
+    run ddev describe
+    assert_success
+    assert_output --partial "Backend:"
+    assert_output --partial "User: default"
+    assert_output --partial "Pass: <none>"
   fi
 
   run ddev redis-cli "KEYS \*"


### PR DESCRIPTION
## The Issue

- https://github.com/ddev/ddev-redis/issues/28#issuecomment-3470308556

> Could it be indicated somehow, when another backend than Redis is in use, like changing CLI wording to `valkey:6379>` ... or maybe it's not really possible?

## How This PR Solves The Issue

Adds override for the container hostname.

## Manual Testing Instructions

```bash
ddev add-on get https://github.com/ddev/ddev-redis/tarball/20251101_stasadev_hostname
ddev redis-backend valkey
ddev restart

ddev redis-cli
# see valkey:6379>

ddev describe
# see backend and pass
```

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
