### PR TITLE
Update to redis 8, fixes #51

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,8 +65,8 @@ Use the `ddev redis-backend` command to swap between Redis backends:
 
 | Command | Docker Image |
 |--------------------------------------|-----------------------------------------------|
-| `ddev redis-backend redis`           | `redis:7`                                     |
-| `ddev redis-backend redis-alpine`    | `redis:7-alpine`                              |
+| `ddev redis-backend redis`           | `redis:8`                                     |
+| `ddev redis-backend redis-alpine`    | `redis:8-alpine`                              |
 | `ddev redis-backend valkey`          | `valkey/valkey:8`                             |
 | `ddev redis-backend valkey-alpine`   | `valkey/valkey:8-alpine`                      |
 | `ddev redis-backend <image>`         | `<image>` (specify your custom Redis image)   |
@@ -96,7 +96,7 @@ Make sure to commit the `.ddev/.env.redis` file to version control.
 To change the used Docker image:
 
 ```bash
-ddev dotenv set .ddev/.env.redis --redis-docker-image=redis:7
+ddev dotenv set .ddev/.env.redis --redis-docker-image=redis:8
 ddev add-on get ddev/ddev-redis
 
 # (optional) if you have an existing Redis volume, delete it to avoid problems with Redis:
@@ -112,7 +112,7 @@ All customization options (use with caution):
 
 | Variable | Flag | Default |
 | -------- | ---- | ------- |
-| `REDIS_DOCKER_IMAGE` | `--redis-docker-image` | `redis:7` |
+| `REDIS_DOCKER_IMAGE` | `--redis-docker-image` | `redis:8` |
 | `REDIS_HOSTNAME` | `--redis-hostname` | `redis` |
 | `REDIS_OPTIMIZED` | `--redis-optimized` | `false` (`true`/`false`) |
 

--- a/commands/host/redis-backend
+++ b/commands/host/redis-backend
@@ -18,8 +18,8 @@ Note that not every Docker image can work right away, and you may need to overri
 the "command:" in the docker-compose.redis_extra.yaml file
 
 Available aliases:
-  redis            redis:7
-  redis-alpine     redis:7-alpine
+  redis            redis:8
+  redis-alpine     redis:8-alpine
   valkey           valkey/valkey:8
   valkey-alpine    valkey/valkey:8-alpine
 
@@ -70,19 +70,19 @@ function check_docker_image() {
 }
 
 function use_docker_image() {
-  [[ "$REDIS_DOCKER_IMAGE" != "redis:7" ]] && ddev dotenv set .ddev/.env.redis --redis-docker-image="$REDIS_DOCKER_IMAGE"
+  [[ "$REDIS_DOCKER_IMAGE" != "redis:8" ]] && ddev dotenv set .ddev/.env.redis --redis-docker-image="$REDIS_DOCKER_IMAGE"
   REPO=$(ddev add-on list --installed -j 2>/dev/null | docker run -i --rm ddev/ddev-utilities jq -r '.raw[] | select(.Name=="redis") | .Repository // empty' 2>/dev/null)
   ddev add-on get "${REPO:-ddev/ddev-redis}"
 }
 
 case "$REDIS_DOCKER_IMAGE" in
   redis)
-    NAME="Redis 7"
-    REDIS_DOCKER_IMAGE="redis:7"
+    NAME="Redis 8"
+    REDIS_DOCKER_IMAGE="redis:8"
     ;;
   redis-alpine)
-    NAME="Redis 7 Alpine"
-    REDIS_DOCKER_IMAGE="redis:7-alpine"
+    NAME="Redis 8 Alpine"
+    REDIS_DOCKER_IMAGE="redis:8-alpine"
     ;;
   valkey)
     NAME="Valkey 8"

--- a/docker-compose.redis.yaml
+++ b/docker-compose.redis.yaml
@@ -2,7 +2,7 @@
 services:
   redis:
     container_name: ddev-${DDEV_SITENAME}-redis
-    image: ${REDIS_DOCKER_IMAGE:-redis:7}
+    image: ${REDIS_DOCKER_IMAGE:-redis:8}
     hostname: ${REDIS_HOSTNAME:-redis}
     # These labels ensure this service is discoverable by ddev.
     labels:
@@ -19,7 +19,7 @@ services:
     command: /etc/redis/conf/redis.conf
     x-ddev:
       describe-url-port: |
-        Backend: ${REDIS_DOCKER_IMAGE:-redis:7}
+        Backend: ${REDIS_DOCKER_IMAGE:-redis:8}
       describe-info: |
         Pass: <none>
 


### PR DESCRIPTION
## The Issue

- Fixes #51 

Redis 7 is EOL. Most webservers are now ready to use Redis 8 (8.8+ actually).

## How This PR Solves The Issue

Update ddev addon to use Redis 8

## Manual Testing Instructions

```bash
ddev add-on get https://github.com/bserem/ddev-redis/tarball/redis8
ddev restart
```
